### PR TITLE
instantiated PrintWriter pout to System.out

### DIFF
--- a/Source Code/PantherLot Main/src/server/storage/ParkingSpot.java
+++ b/Source Code/PantherLot Main/src/server/storage/ParkingSpot.java
@@ -15,7 +15,7 @@ public class ParkingSpot implements Comparable
     
     int floor;
     String direction;
-    PrintWriter pout;
+    PrintWriter pout = new PrintWriter(System.out);
     
     /*
      * String that stores the number of the parking spot


### PR DESCRIPTION
Before the PrintWriter pout was null and hence when the program ran, the connection status would be off and therefore any attempt at request for a parking spot would yield "no parking spot available" type of warning. By instantiating it we can actually get parkingSpots. 